### PR TITLE
Add option to specify dialog header colour as input to feedback directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ easy to use the directive, just add it in a html tag, such as:
 | `highlightTip`   | highlight issues                                                      |
 | `hideTip`        | hide sensitive info                                                   |
 | `editDoneLabel`  | DONE                                                                  |
+| `headerColour`   | rgb(96, 125, 139)                                                      |
 
 ### method
 

--- a/src/app/feedback/feedback-dialog/feedback-dialog.component.html
+++ b/src/app/feedback/feedback-dialog/feedback-dialog.component.html
@@ -1,5 +1,5 @@
 <div class="dialog" *ngIf="!showToolbar" data-html2canvas-ignore="true">
-  <div class="dialog-title">
+  <div class="dialog-title" [ngStyle]="{background: vars['headerColour']}">
     <div class="title-font">
       {{vars['title']}}
     </div>

--- a/src/app/feedback/feedback.directive.ts
+++ b/src/app/feedback/feedback.directive.ts
@@ -18,6 +18,7 @@ export class FeedbackDirective implements OnInit {
   @Input() highlightTip = 'highlight issues';
   @Input() hideTip = 'hide sensitive info';
   @Input() editDoneLabel = 'DONE';
+  @Input() headerColour = 'rgb(96, 125, 139)';
   @Output() public send = new EventEmitter<object>();
 
   public constructor(private dialogRef: MatDialog, private feedbackService: FeedbackService, overlay: Overlay) {
@@ -58,7 +59,8 @@ export class FeedbackDirective implements OnInit {
       drawRectTip: this.drawRectTip,
       highlightTip: this.highlightTip,
       hideTip: this.hideTip,
-      editDoneLabel: this.editDoneLabel
+      editDoneLabel: this.editDoneLabel,
+      headerColour: this.headerColour
     };
   }
 


### PR DESCRIPTION
This feature will allow for the feedback dialog's header colour to be customized by the user by passing an input value into the headerColour input property of the feedback directive.

`<button mat-raised-button color="primary" feedback [headerColour]="'red'" (send)="onSend($event)">
    feedback
  </button>`

![image](https://user-images.githubusercontent.com/43771950/71111537-57e9a480-21d2-11ea-96ed-67a2c5c1eabe.png)
